### PR TITLE
update dockerfile for nginx plus package installation

### DIFF
--- a/docker/docker-files/nginxplus-ubuntu18.04/Dockerfile-ubuntu-18.04-nginx-25
+++ b/docker/docker-files/nginxplus-ubuntu18.04/Dockerfile-ubuntu-18.04-nginx-25
@@ -6,7 +6,7 @@ LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 # Uncomment this block and the versioned nginxPackages in the main RUN
 # instruction to install a specific release
 # https://docs.nginx.com/nginx/releases/
-ENV NGINX_VERSION 25
+ENV NGINX_VERSION 25 
 # https://nginx.org/en/docs/njs/changes.html
 ENV NJS_VERSION   0.6.2
 # https://plus-pkgs.nginx.com 1~bionic
@@ -27,15 +27,11 @@ RUN set -x \
     && adduser --system --disabled-login --ingroup nginx --no-create-home --home /nonexistent --gecos "nginx user" --shell /bin/false --uid 1001 nginx \
     # Install prerequisite packages, vim for editing, then Install NGINX Plus
     && apt-get update && apt-get upgrade -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --no-install-recommends apt-transport-https lsb-release ca-certificates wget dnsutils gnupg2 vim-tiny apt-utils ubuntu-keyring jq
-
-RUN set -x \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --no-install-recommends apt-transport-https lsb-release ca-certificates wget dnsutils gnupg vim-tiny apt-utils jq \
     # Install NGINX Plus from repo (https://cs.nginx.com/repo_setup)
-    && wget -qO - https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null \
-    && printf "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/ubuntu `lsb_release -cs` nginx-plus\n" | tee /etc/apt/sources.list.d/nginx-plus.list
-
-RUN set -x \
-    && wget -P /etc/apt/apt.conf.d https://cs.nginx.com/static/files/90pkgs-nginx \
+    && wget http://nginx.org/keys/nginx_signing.key && apt-key add nginx_signing.key \
+    && printf "deb https://plus-pkgs.nginx.com/ubuntu `lsb_release -cs` nginx-plus\n" | tee /etc/apt/sources.list.d/nginx-plus.list \
+    && wget -P /etc/apt/apt.conf.d https://cs.nginx.com/static/files/90nginx \
     && apt-get update \
     #
     ## Install the latest release of NGINX Plus and/or NGINX Plus modules


### PR DESCRIPTION
Updated and backup Dockerfile based on the latest change of NGINX installation instruction as follows:

## Installation instructions for Ubuntu Linux
- If you already have old NGINX packages in your system, back up your configs and logs:
  ```bash
  sudo cp -a /etc/nginx /etc/nginx-plus-backup
  sudo cp -a /var/log/nginx /var/log/nginx-plus-backup
  ```
- Create the /etc/ssl/nginx/ directory:
  ```bash
  sudo mkdir -p /etc/ssl/nginx
  ```
- Install apt utils:
  ```bash
  sudo apt-get install apt-transport-https lsb-release ca-certificates wget gnupg2 ubuntu-keyring
  ```
- Log in to [MyF5](https://my.f5.com/), if you purchased subscription, or follow the link in the trial activation email, and download the following two files:
  ```
  nginx-repo.key
  nginx-repo.crt  ```

- Copy the above two files to the Ubuntu Linux server into `/etc/ssl/nginx/` directory. Use your SCP client or other secure file transfer tools.
- Download and add [NGINX signing key](https://cs.nginx.com/static/keys/nginx_signing.key):
  ```bash
  wget -qO - https://cs.nginx.com/static/keys/nginx_signing.key | gpg --dearmor | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
  ```
- Add NGINX Plus repository:
  ```bash
  printf "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/ubuntu `lsb_release -cs` nginx-plus\n" | sudo tee /etc/apt/sources.list.d/nginx-plus.list
  ```
- If you have modsecurity subscription, add modsecurity repository:
  ```bash
  printf "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/modsecurity/ubuntu `lsb_release -cs` nginx-plus\n" | sudo tee /etc/apt/sources.list.d/nginx-modsecurity.list
  ```
- Download [nginx-plus](https://cs.nginx.com/static/files/90pkgs-nginx) apt configuration files to /etc/apt/apt.conf.d:
  ```bash
  sudo wget -P /etc/apt/apt.conf.d https://cs.nginx.com/static/files/90pkgs-nginx
  ```
- Update the repository and install NGINX Plus:
  ```bash
  sudo apt-get update
  sudo apt-get install nginx-plus
  ```
- Install modsecurity, in case you have modsecurity subscription:
  ```bash
  sudo apt-get install nginx-plus nginx-plus-module-modsecurity
  ```
- Check the `nginx` binary version to ensure that you have NGINX Plus installed correctly:
  ```bash
  nginx -v
  ```

## Upgrading to a specific release
- In order to upgrade from the previous version of nginx-plus, run `apt-get update` and `apt-get install nginx-plus`

- Default repository path is configured to point to the latest NGINX Plus release with an ability to downgrade to one of the previous releases issued within 2 years. If you want to stick to the particular release, you should modify repository URL in the `/etc/apt/sources.list.d/nginx-plus.list` file in a following way:

  ```bash
  deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://pkgs.nginx.com/plus/Rxx/ubuntu ...
  ```

- where `xx` is a release number.

- Make the same changes to the `/etc/apt/sources.list.d/nginx-modsecurity.list` file, if you have appropriate subscription.

Please check [NGINX Plus Releases History](https://www.nginx.com/resources/admin-guide/nginx-plus-releases/) for more information about the latest NGINX Plus updates.

Also please visit [NGINX Plus Admin Guide](https://docs.nginx.com/nginx/admin-guide/) for more information about NGINX Plus initial deployment, configuration and tuning.

For NGINX App Protect WAF repositories setup instructions, please visit [NGINX App Protect WAF Administration Guide](https://docs.nginx.com/nginx-app-protect-waf/admin-guide/install/).